### PR TITLE
Fix compile warnings

### DIFF
--- a/players/strategies/src/NegamaxStrategy.cpp
+++ b/players/strategies/src/NegamaxStrategy.cpp
@@ -18,12 +18,13 @@ NegamaxStrategy::NegamaxStrategy() {
 }
 
 bool NegamaxStrategy::makesFive(const Board &board, int r, int c, int8_t who) const {
+    const int N = static_cast<int>(Board::N);
     for (auto &d : DIR) {
         int cnt = 1;
         for (int step = 1; step < 5; ++step) {
             int nr = r + d[1] * step;
             int nc = c + d[0] * step;
-            if (nr < 0 || nr >= Board::N || nc < 0 || nc >= Board::N) break;
+            if (nr < 0 || nr >= N || nc < 0 || nc >= N) break;
             if (board.at(nr, nc) == who)
                 cnt++;
             else
@@ -32,7 +33,7 @@ bool NegamaxStrategy::makesFive(const Board &board, int r, int c, int8_t who) co
         for (int step = 1; step < 5; ++step) {
             int nr = r - d[1] * step;
             int nc = c - d[0] * step;
-            if (nr < 0 || nr >= Board::N || nc < 0 || nc >= Board::N) break;
+            if (nr < 0 || nr >= N || nc < 0 || nc >= N) break;
             if (board.at(nr, nc) == who)
                 cnt++;
             else
@@ -44,11 +45,12 @@ bool NegamaxStrategy::makesFive(const Board &board, int r, int c, int8_t who) co
 }
 
 bool NegamaxStrategy::hasNeighbor(const Board &board, int r, int c) const {
+    const int N = static_cast<int>(Board::N);
     for (int dr = -1; dr <= 1; ++dr) {
         for (int dc = -1; dc <= 1; ++dc) {
             if (dr == 0 && dc == 0) continue;
             int nr = r + dr, nc = c + dc;
-            if (nr < 0 || nr >= Board::N || nc < 0 || nc >= Board::N) continue;
+            if (nr < 0 || nr >= N || nc < 0 || nc >= N) continue;
             if (!board.isEmpty(nr, nc)) return true;
         }
     }
@@ -65,16 +67,18 @@ void NegamaxStrategy::undoMove(Board &board, std::pair<int, int> pos) {
 
 std::pair<int,int> NegamaxStrategy::computeMove(Board &board, int8_t player) {
     int8_t opponent = (player == 1 ? -1 : 1);
-    for (int r = 0; r < Board::N; ++r) {
-        for (int c = 0; c < Board::N; ++c) {
+    for (size_t r = 0; r < Board::N; ++r) {
+        for (size_t c = 0; c < Board::N; ++c) {
             if (!board.isEmpty(r, c)) continue;
-            if (makesFive(board, r, c, player)) return {r, c};
+            if (makesFive(board, static_cast<int>(r), static_cast<int>(c), player))
+                return {static_cast<int>(r), static_cast<int>(c)};
         }
     }
-    for (int r = 0; r < Board::N; ++r) {
-        for (int c = 0; c < Board::N; ++c) {
+    for (size_t r = 0; r < Board::N; ++r) {
+        for (size_t c = 0; c < Board::N; ++c) {
             if (!board.isEmpty(r, c)) continue;
-            if (makesFive(board, r, c, opponent)) return {r, c};
+            if (makesFive(board, static_cast<int>(r), static_cast<int>(c), opponent))
+                return {static_cast<int>(r), static_cast<int>(c)};
         }
     }
     if (board.isFull()) return {-1, -1};
@@ -83,8 +87,8 @@ std::pair<int,int> NegamaxStrategy::computeMove(Board &board, int8_t player) {
     static std::array<std::array<std::array<uint64_t, 2>, Board::N>, Board::N> zobrist;
     if (!zobristInitialized) {
         std::mt19937_64 rng(0xdeadbeef);
-        for (int r = 0; r < Board::N; ++r) {
-            for (int c = 0; c < Board::N; ++c) {
+        for (size_t r = 0; r < Board::N; ++r) {
+            for (size_t c = 0; c < Board::N; ++c) {
                 zobrist[r][c][0] = rng();
                 zobrist[r][c][1] = rng();
             }
@@ -96,8 +100,8 @@ std::pair<int,int> NegamaxStrategy::computeMove(Board &board, int8_t player) {
 
     auto evaluateBoard = [&](const Board &b) {
         int score = 0;
-        for (int r = 0; r < Board::N; ++r) {
-            for (int c = 0; c < Board::N; ++c) {
+        for (size_t r = 0; r < Board::N; ++r) {
+            for (size_t c = 0; c < Board::N; ++c) {
                 int8_t val = b.at(r, c);
                 if (val == 1)
                     score += 1;
@@ -127,29 +131,30 @@ std::pair<int,int> NegamaxStrategy::computeMove(Board &board, int8_t player) {
         int origAlpha = alpha;
         std::vector<std::pair<int,int>> moves;
         moves.reserve(Board::N*Board::N);
-        for (int r = 0; r < Board::N; ++r) {
-            for (int c = 0; c < Board::N; ++c) {
+        for (size_t r = 0; r < Board::N; ++r) {
+            for (size_t c = 0; c < Board::N; ++c) {
                 if (!b.isEmpty(r,c)) continue;
-                if (!hasNeighbor(b,r,c)) continue;
-                moves.emplace_back(r,c);
+                if (!hasNeighbor(b, static_cast<int>(r), static_cast<int>(c))) continue;
+                moves.emplace_back(static_cast<int>(r), static_cast<int>(c));
             }
         }
         if (moves.empty()) {
-            for (int r = 0; r < Board::N; ++r) {
-                for (int c = 0; c < Board::N; ++c) {
-                    if (b.isEmpty(r,c)) moves.emplace_back(r,c);
+            for (size_t r = 0; r < Board::N; ++r) {
+                for (size_t c = 0; c < Board::N; ++c) {
+                    if (b.isEmpty(r,c)) moves.emplace_back(static_cast<int>(r), static_cast<int>(c));
                 }
             }
         }
         std::sort(moves.begin(), moves.end(), [&](const auto &m1, const auto &m2){
+            const int N = static_cast<int>(Board::N);
             int count1 = 0, count2 = 0;
             for (int dr=-1; dr<=1; ++dr) {
                 for (int dc=-1; dc<=1; ++dc) {
                     if (dr==0 && dc==0) continue;
                     int nr1 = m1.first+dr, nc1 = m1.second+dc;
                     int nr2 = m2.first+dr, nc2 = m2.second+dc;
-                    if (nr1>=0 && nr1<Board::N && nc1>=0 && nc1<Board::N && !b.isEmpty(nr1,nc1)) count1++;
-                    if (nr2>=0 && nr2<Board::N && nc2>=0 && nc2<Board::N && !b.isEmpty(nr2,nc2)) count2++;
+                    if (nr1>=0 && nr1<N && nc1>=0 && nc1<N && !b.isEmpty(nr1,nc1)) count1++;
+                    if (nr2>=0 && nr2<N && nc2>=0 && nc2<N && !b.isEmpty(nr2,nc2)) count2++;
                 }
             }
             return count1 > count2;
@@ -184,8 +189,8 @@ std::pair<int,int> NegamaxStrategy::computeMove(Board &board, int8_t player) {
     auto start = std::chrono::steady_clock::now();
     const int limitMs = 1000;
     uint64_t rootHash = 0ULL;
-    for (int r=0; r<Board::N; ++r) {
-        for (int c=0; c<Board::N; ++c) {
+    for (size_t r=0; r<Board::N; ++r) {
+        for (size_t c=0; c<Board::N; ++c) {
             int8_t val = board.at(r,c);
             if (val != 0) rootHash ^= zobrist[r][c][(val==1?0:1)];
         }
@@ -195,29 +200,30 @@ std::pair<int,int> NegamaxStrategy::computeMove(Board &board, int8_t player) {
         std::pair<int,int> currentBest{-1,-1};
         int currentBestVal=-1000000000;
         std::vector<std::pair<int,int>> rootMoves;
-        for (int r=0; r<Board::N; ++r) {
-            for (int c=0; c<Board::N; ++c) {
+        for (size_t r=0; r<Board::N; ++r) {
+            for (size_t c=0; c<Board::N; ++c) {
                 if (!board.isEmpty(r,c)) continue;
-                if (!hasNeighbor(board,r,c)) continue;
-                rootMoves.emplace_back(r,c);
+                if (!hasNeighbor(board, static_cast<int>(r), static_cast<int>(c))) continue;
+                rootMoves.emplace_back(static_cast<int>(r), static_cast<int>(c));
             }
         }
         if (rootMoves.empty()) {
-            for (int r=0; r<Board::N; ++r) {
-                for (int c=0; c<Board::N; ++c) {
-                    if (board.isEmpty(r,c)) rootMoves.emplace_back(r,c);
+            for (size_t r=0; r<Board::N; ++r) {
+                for (size_t c=0; c<Board::N; ++c) {
+                    if (board.isEmpty(r,c)) rootMoves.emplace_back(static_cast<int>(r), static_cast<int>(c));
                 }
             }
         }
         std::sort(rootMoves.begin(), rootMoves.end(), [&](const auto &m1, const auto &m2){
+            const int N = static_cast<int>(Board::N);
             int count1=0,count2=0;
             for (int dr=-1; dr<=1; ++dr){
                 for (int dc=-1; dc<=1; ++dc){
                     if (dr==0 && dc==0) continue;
                     int nr1=m1.first+dr,nc1=m1.second+dc;
                     int nr2=m2.first+dr,nc2=m2.second+dc;
-                    if (nr1>=0&&nr1<Board::N&&nc1>=0&&nc1<Board::N&&!board.isEmpty(nr1,nc1)) count1++;
-                    if (nr2>=0&&nr2<Board::N&&nc2>=0&&nc2<Board::N&&!board.isEmpty(nr2,nc2)) count2++;
+                    if (nr1>=0&&nr1<N&&nc1>=0&&nc1<N&&!board.isEmpty(nr1,nc1)) count1++;
+                    if (nr2>=0&&nr2<N&&nc2>=0&&nc2<N&&!board.isEmpty(nr2,nc2)) count2++;
                 }
             }
             return count1>count2;
@@ -248,14 +254,14 @@ std::pair<int,int> NegamaxStrategy::computeMove(Board &board, int8_t player) {
     }
 
     if (bestMove.first == -1 || bestMove.second == -1) {
-        for (int r=0; r<Board::N; ++r) {
-            for (int c=0; c<Board::N; ++c) {
-                if (board.isEmpty(r,c) && hasNeighbor(board,r,c)) return {r,c};
+        for (size_t r=0; r<Board::N; ++r) {
+            for (size_t c=0; c<Board::N; ++c) {
+                if (board.isEmpty(r,c) && hasNeighbor(board, static_cast<int>(r), static_cast<int>(c))) return {static_cast<int>(r),static_cast<int>(c)};
             }
         }
-        for (int r=0; r<Board::N; ++r) {
-            for (int c=0; c<Board::N; ++c) {
-                if (board.isEmpty(r,c)) return {r,c};
+        for (size_t r=0; r<Board::N; ++r) {
+            for (size_t c=0; c<Board::N; ++c) {
+                if (board.isEmpty(r,c)) return {static_cast<int>(r),static_cast<int>(c)};
             }
         }
         return {-1,-1};

--- a/players/strategies/src/SimpleRuleStrategy.cpp
+++ b/players/strategies/src/SimpleRuleStrategy.cpp
@@ -5,16 +5,17 @@ static constexpr int DIR[4][2] = {
 };
 
 static bool makesFive(const Board &board,int r,int c,int8_t who){
+    const int N = static_cast<int>(Board::N);
     for(auto &d:DIR){
         int cnt=1;
         for(int s=1;s<5;++s){
             int nr=r+d[1]*s,nc=c+d[0]*s;
-            if(nr<0||nr>=Board::N||nc<0||nc>=Board::N) break;
+            if(nr<0||nr>=N||nc<0||nc>=N) break;
             if(board.at(nr,nc)==who) cnt++; else break;
         }
         for(int s=1;s<5;++s){
             int nr=r-d[1]*s,nc=c-d[0]*s;
-            if(nr<0||nr>=Board::N||nc<0||nc>=Board::N) break;
+            if(nr<0||nr>=N||nc<0||nc>=N) break;
             if(board.at(nr,nc)==who) cnt++; else break;
         }
         if(cnt>=5) return true;
@@ -24,21 +25,23 @@ static bool makesFive(const Board &board,int r,int c,int8_t who){
 
 std::pair<int,int> SimpleRuleStrategy::computeMove(Board &board,int8_t player){
     int8_t opponent = player==1?-1:1;
-    for(int r=0;r<Board::N;++r){
-        for(int c=0;c<Board::N;++c){
+    for(size_t r=0;r<Board::N;++r){
+        for(size_t c=0;c<Board::N;++c){
             if(!board.isEmpty(r,c)) continue;
-            if(makesFive(board,r,c,player)) return {r,c};
+            if(makesFive(board,static_cast<int>(r),static_cast<int>(c),player))
+                return {static_cast<int>(r),static_cast<int>(c)};
         }
     }
-    for(int r=0;r<Board::N;++r){
-        for(int c=0;c<Board::N;++c){
+    for(size_t r=0;r<Board::N;++r){
+        for(size_t c=0;c<Board::N;++c){
             if(!board.isEmpty(r,c)) continue;
-            if(makesFive(board,r,c,opponent)) return {r,c};
+            if(makesFive(board,static_cast<int>(r),static_cast<int>(c),opponent))
+                return {static_cast<int>(r),static_cast<int>(c)};
         }
     }
-    for(int r=0;r<Board::N;++r){
-        for(int c=0;c<Board::N;++c){
-            if(board.isEmpty(r,c)) return {r,c};
+    for(size_t r=0;r<Board::N;++r){
+        for(size_t c=0;c<Board::N;++c){
+            if(board.isEmpty(r,c)) return {static_cast<int>(r),static_cast<int>(c)};
         }
     }
     return {-1,-1};

--- a/tests/test_ai.cpp
+++ b/tests/test_ai.cpp
@@ -24,8 +24,8 @@ static void blockOpponent() {
 
 static void fullBoard() {
     Board b;
-    for (int r = 0; r < Board::N; ++r)
-        for (int c = 0; c < Board::N; ++c) b.placeStone(r, c, 1);
+    for (size_t r = 0; r < Board::N; ++r)
+        for (size_t c = 0; c < Board::N; ++c) b.placeStone(r, c, 1);
     AIPlayer ai;
     auto move = ai.getMove(b, 1);
     assert(move.first == -1 && move.second == -1);

--- a/tests/test_board.cpp
+++ b/tests/test_board.cpp
@@ -40,8 +40,8 @@ static void noWin() {
 
 static void fullBoard() {
     Board b;
-    for (int r = 0; r < Board::N; ++r)
-        for (int c = 0; c < Board::N; ++c) b.placeStone(r, c, 1);
+    for (size_t r = 0; r < Board::N; ++r)
+        for (size_t c = 0; c < Board::N; ++c) b.placeStone(r, c, 1);
     assert(b.isFull());
 }
 
@@ -49,8 +49,8 @@ static void overwriteCell() {
     Board b;
     b.placeStone(0, 0, 1);
     b.placeStone(0, 0, -1);
-    for (int r = 0; r < Board::N; ++r)
-        for (int c = 0; c < Board::N; ++c)
+    for (size_t r = 0; r < Board::N; ++r)
+        for (size_t c = 0; c < Board::N; ++c)
             if (!(r == 0 && c == 0)) b.placeStone(r, c, 1);
     assert(b.isFull());
 }

--- a/tests/test_renderer.cpp
+++ b/tests/test_renderer.cpp
@@ -25,8 +25,8 @@ static void boundaryChecks() {
     Terminal t;
     Board b;
     Renderer r(t, b);
-    for (int i = 0; i < Board::N * 2; ++i) r.handleKey(TermKey::Up);
-    for (int i = 0; i < Board::N * 2; ++i) r.handleKey(TermKey::Left);
+    for (size_t i = 0; i < Board::N * 2; ++i) r.handleKey(TermKey::Up);
+    for (size_t i = 0; i < Board::N * 2; ++i) r.handleKey(TermKey::Left);
     auto pos = r.cursor();
     assert(pos.first == 0 && pos.second == 0);
     r.handleKey(TermKey::Up);
@@ -34,8 +34,8 @@ static void boundaryChecks() {
     pos = r.cursor();
     assert(pos.first == 0 && pos.second == 0);
 
-    for (int i = 0; i < Board::N * 2; ++i) r.handleKey(TermKey::Down);
-    for (int i = 0; i < Board::N * 2; ++i) r.handleKey(TermKey::Right);
+    for (size_t i = 0; i < Board::N * 2; ++i) r.handleKey(TermKey::Down);
+    for (size_t i = 0; i < Board::N * 2; ++i) r.handleKey(TermKey::Right);
     pos = r.cursor();
     assert(pos.first == Board::N - 1 && pos.second == Board::N - 1);
     r.handleKey(TermKey::Down);

--- a/ui/src/Renderer.cpp
+++ b/ui/src/Renderer.cpp
@@ -12,18 +12,19 @@ void Renderer::draw() {
     out += "\x1b[2J";  // clear screen
     out += "=================  Gomoku (五子棋) =================\n\n";
     out += "     ";
-    for (int c = 1; c <= Board::N; ++c) {
+    for (size_t c = 1; c <= Board::N; ++c) {
         out += std::to_string(c);
         if (c < 10) out += ' ';
         out += ' ';
     }
     out += "\n";
-    for (int r = 0; r < Board::N; ++r) {
+    for (size_t r = 0; r < Board::N; ++r) {
         if (r + 1 < 10) out += ' ';
         out += std::to_string(r + 1);
         out += " | ";
-        for (int c = 0; c < Board::N; ++c) {
-            bool highlight = (r == cur_row_ && c == cur_col_);
+        for (size_t c = 0; c < Board::N; ++c) {
+            bool highlight = (r == static_cast<size_t>(cur_row_) &&
+                              c == static_cast<size_t>(cur_col_));
             if (highlight) out += "\x1b[7m";
             int cell = board_.at(r, c);
             if (cell == 0)

--- a/ui/src/TerminalUI.cpp
+++ b/ui/src/TerminalUI.cpp
@@ -10,20 +10,21 @@ void TerminalUI::drawBoard(const Board &board) {
     buffer += "\x1b[2J";  // clear screen
     buffer += "=================  Gomoku (五子棋) =================\n\n";
     buffer += "     ";
-    for (int c = 1; c <= static_cast<int>(Board::N); ++c) {
+    for (size_t c = 1; c <= Board::N; ++c) {
         buffer += std::to_string(c);
-        if (c < 10) buffer += ' ';
+        if (c < 10u) buffer += ' ';
         buffer += ' ';
     }
     buffer += '\n';
 
     auto [curRow, curCol] = renderer_.cursor();
-    for (int r = 0; r < static_cast<int>(Board::N); ++r) {
-        if (r + 1 < 10) buffer += ' ';
+    for (size_t r = 0; r < Board::N; ++r) {
+        if (r + 1 < 10u) buffer += ' ';
         buffer += std::to_string(r + 1);
         buffer += " | ";
-        for (int c = 0; c < static_cast<int>(Board::N); ++c) {
-            bool highlight = (r == curRow && c == curCol);
+        for (size_t c = 0; c < Board::N; ++c) {
+            bool highlight = (r == static_cast<size_t>(curRow) &&
+                              c == static_cast<size_t>(curCol));
             if (highlight) buffer += "\x1b[7m";
             int cell = board.at(r, c);
             if (cell == 0)
@@ -39,7 +40,7 @@ void TerminalUI::drawBoard(const Board &board) {
     }
     buffer += "\nUse Arrow keys, Enter to place, Q to quit.\n";
 
-    ::write(STDOUT_FILENO, buffer.data(), buffer.size());
+    term_.writeBuffer(buffer);
 }
 
 void TerminalUI::showResult(int8_t winner) {


### PR DESCRIPTION
## Summary
- eliminate signed/unsigned comparison warnings by using size_t indices
- add explicit casts when interacting with int-based APIs
- ensure write() return value is ignored via Terminal::writeBuffer
- update tests to use size_t loops

## Testing
- `make`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68498ac0f90c83228e7997f41d1d9918