### PR TITLE
Add missing tests for GameLogic and Board

### DIFF
--- a/tests/test_board.cpp
+++ b/tests/test_board.cpp
@@ -55,6 +55,18 @@ static void overwriteCell() {
     assert(b.isFull());
 }
 
+static void removeStone() {
+    Board b;
+    b.placeStone(0, 0, 1);
+    b.removeStone(0, 0);
+    for (size_t r = 0; r < Board::N; ++r)
+        for (size_t c = 0; c < Board::N; ++c)
+            if (!(r == 0 && c == 0)) b.placeStone(r, c, 1);
+    assert(!b.isFull());
+    assert(b.isEmpty(0, 0));
+    assert(b.at(0, 0) == 0);
+}
+
 int main() {
     horizontalWin();
     verticalWin();
@@ -63,6 +75,7 @@ int main() {
     noWin();
     fullBoard();
     overwriteCell();
+    removeStone();
     std::cout << "board tests passed\n";
     return 0;
 }

--- a/tests/test_board.cpp
+++ b/tests/test_board.cpp
@@ -67,6 +67,22 @@ static void removeStone() {
     assert(b.at(0, 0) == 0);
 }
 
+static void resetBoard() {
+    Board b;
+    b.placeStone(0, 0, 1);
+    b.placeStone(1, 1, -1);
+    b.reset();
+    assert(b.isEmpty(0, 0));
+    assert(b.isEmpty(1, 1));
+    assert(!b.isFull());
+}
+
+static void boundsCheck() {
+    Board b;
+    assert(b.at(Board::N, Board::N) == 0);
+    assert(!b.isEmpty(Board::N, Board::N));
+}
+
 int main() {
     horizontalWin();
     verticalWin();
@@ -76,6 +92,8 @@ int main() {
     fullBoard();
     overwriteCell();
     removeStone();
+    resetBoard();
+    boundsCheck();
     std::cout << "board tests passed\n";
     return 0;
 }

--- a/tests/test_gamelogic.cpp
+++ b/tests/test_gamelogic.cpp
@@ -1,0 +1,74 @@
+#include <cassert>
+#include <iostream>
+#include <vector>
+
+#include "Board.hpp"
+#include "GameLogic.hpp"
+#include "IPlayer.hpp"
+#include "IGameUI.hpp"
+#include "IInput.hpp"
+
+class DummyPlayer : public IPlayer {
+    std::vector<std::pair<int, int>> moves_;
+    size_t idx_ = 0;
+
+public:
+    explicit DummyPlayer(std::vector<std::pair<int, int>> moves)
+        : moves_(std::move(moves)) {}
+    std::pair<int, int> getMove(const Board &, int8_t) override {
+        if (idx_ >= moves_.size())
+            return {-1, -1};
+        return moves_[idx_++];
+    }
+};
+
+class DummyUI : public IGameUI {
+public:
+    int drawCount = 0;
+    int showCount = 0;
+    int8_t lastWinner = 0;
+
+    void drawBoard(const Board &) override { drawCount++; }
+    void showResult(int8_t winner) override {
+        showCount++;
+        lastWinner = winner;
+    }
+};
+
+class DummyInput : public IInput {
+public:
+    std::pair<int, int> getSelection() override { return {-1, -1}; }
+};
+
+static void playerOneWins() {
+    Board b;
+    DummyPlayer p1({{7, 0}, {7, 1}, {7, 2}, {7, 3}, {7, 4}});
+    DummyPlayer p2({{0, 0}, {0, 1}, {0, 2}, {0, 3}});
+    std::vector<IPlayer *> players{&p1, &p2};
+    DummyUI ui;
+    DummyInput in;
+    GameLogic g(b, players, ui, in);
+    int8_t winner = g.run();
+    assert(winner == 1);
+    assert(ui.lastWinner == 1);
+}
+
+static void earlyQuit() {
+    Board b;
+    DummyPlayer p1({{-1, -1}});
+    DummyPlayer p2({});
+    std::vector<IPlayer *> players{&p1, &p2};
+    DummyUI ui;
+    DummyInput in;
+    GameLogic g(b, players, ui, in);
+    int8_t winner = g.run();
+    assert(winner == 0);
+    assert(ui.lastWinner == 0);
+}
+
+int main() {
+    playerOneWins();
+    earlyQuit();
+    std::cout << "gamelogic tests passed\n";
+    return 0;
+}

--- a/tests/test_gamelogic.cpp
+++ b/tests/test_gamelogic.cpp
@@ -66,9 +66,31 @@ static void earlyQuit() {
     assert(ui.lastWinner == 0);
 }
 
+static void drawGame() {
+    Board b;
+    for (size_t r = 0; r < Board::N; ++r) {
+        int8_t start = (r % 4 < 2) ? 1 : -1;
+        for (size_t c = 0; c < Board::N; ++c) {
+            if (r == Board::N - 1 && c == Board::N - 1) break;
+            int8_t val = (c % 2 == 0) ? start : -start;
+            b.placeStone(r, c, val);
+        }
+    }
+    DummyPlayer p1({{Board::N - 1, Board::N - 1}});
+    DummyPlayer p2({});
+    std::vector<IPlayer *> players{&p1, &p2};
+    DummyUI ui;
+    DummyInput in;
+    GameLogic g(b, players, ui, in);
+    int8_t winner = g.run();
+    assert(winner == 0);
+    assert(ui.lastWinner == 0);
+}
+
 int main() {
     playerOneWins();
     earlyQuit();
+    drawGame();
     std::cout << "gamelogic tests passed\n";
     return 0;
 }


### PR DESCRIPTION
## Summary
- expand board tests with removeStone check
- add new gamelogic tests for win and early quit scenarios

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68499575d20c8322a6ff165895af9bd4