### PR TITLE
Reduce std::cout usage in TerminalUI

### DIFF
--- a/ui/include/Terminal.hpp
+++ b/ui/include/Terminal.hpp
@@ -18,6 +18,7 @@ public:
 
     TermKey readKey();
     void writeBuffer(const std::string &s);
+    void writeLine(const std::string &s);
 
     // ANSI operations
     void clearLine();

--- a/ui/src/Terminal.cpp
+++ b/ui/src/Terminal.cpp
@@ -65,3 +65,8 @@ void Terminal::writeBuffer(const std::string &s) {
     auto _ = ::write(STDOUT_FILENO, s.data(), s.size());
     (void)_;
 }
+
+void Terminal::writeLine(const std::string &s) {
+    writeBuffer(s);
+    writeBuffer("\n");
+}

--- a/ui/src/TerminalUI.cpp
+++ b/ui/src/TerminalUI.cpp
@@ -1,6 +1,5 @@
 #include "TerminalUI.hpp"
 #include <unistd.h>
-#include <iostream>
 #include <string>
 
 void TerminalUI::drawBoard(const Board & /*board*/) {
@@ -11,7 +10,7 @@ void TerminalUI::showResult(int8_t winner) {
     term_.moveCursor(Board::N + 6, 1);
     term_.clearLine();
     if (winner == 0)
-        std::cout << "Draw!\n";
+        term_.writeLine("Draw!");
     else
-        std::cout << "Player " << (winner == 1 ? "●" : "○") << " wins!\n";
+        term_.writeLine(std::string("Player ") + (winner == 1 ? "●" : "○") + " wins!");
 }


### PR DESCRIPTION
## Summary
- route game result messages through `Terminal`
- add `writeLine()` helper to `Terminal`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6849a6fce4e08322a1daa3fc0aa2395b