### PR TITLE
Consolidate board rendering

### DIFF
--- a/players/src/HumanPlayer.cpp
+++ b/players/src/HumanPlayer.cpp
@@ -4,7 +4,7 @@
 HumanPlayer::HumanPlayer(IInput &input, IGameUI &ui) : input_(input), ui_(ui) {}
 
 std::pair<int, int> HumanPlayer::getMove(const Board &board, int8_t player) {
+    (void)board;
     (void)player;
-    ui_.drawBoard(board);
     return input_.getSelection();
 }

--- a/tests/test_gamelogic.cpp
+++ b/tests/test_gamelogic.cpp
@@ -43,6 +43,7 @@ static void playerOneWins() {
     int8_t winner = g.run();
     assert(winner == 1);
     assert(ui.lastWinner == 1);
+    assert(ui.drawCount == 10); // 9 turns + final board
 }
 
 static void earlyQuit() {
@@ -55,6 +56,7 @@ static void earlyQuit() {
     int8_t winner = g.run();
     assert(winner == 0);
     assert(ui.lastWinner == 0);
+    assert(ui.drawCount == 1); // one turn with early quit
 }
 
 static void drawGame() {
@@ -75,6 +77,7 @@ static void drawGame() {
     int8_t winner = g.run();
     assert(winner == 0);
     assert(ui.lastWinner == 0);
+    assert(ui.drawCount == 2); // one turn plus final board
 }
 
 static void invalidPlayers() {


### PR DESCRIPTION
## Summary
- avoid double drawing in `HumanPlayer`
- count board draws in `GameLogic` tests

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6849ada9d9a48322bba43b71d9f31ac3